### PR TITLE
VM Host Package Caching

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+# Flake8 configuration file
+# http://flake8.pycqa.org/en/latest/user/configuration.html
+[flake8]
+max-line-length = 100

--- a/roles/virtserver/meta/main.yaml
+++ b/roles/virtserver/meta/main.yaml
@@ -2,3 +2,4 @@
 dependencies:
   - { role: ansible-provisioning }
   - { role: debops.libvirtd }
+  - { role: debops.apt_cacher_ng }

--- a/roles/virtserver/molecule/default/molecule.yml
+++ b/roles/virtserver/molecule/default/molecule.yml
@@ -29,6 +29,8 @@ provisioner:
     group_vars:
       vm_hosts:
         vm_host: "{{ inventory_hostname }}"
+        # Pass given proxy to apt-cacher-ng running on VM host
+        apt_cacher_ng__proxy: "{{ lookup('env', 'http_proxy') }}"
         vm_type: qemu
         vm_memory: 2048
         vm_vcpu: 2

--- a/roles/virtserver/molecule/default/molecule.yml
+++ b/roles/virtserver/molecule/default/molecule.yml
@@ -39,3 +39,5 @@ verifier:
   name: testinfra
   lint:
     name: flake8
+    options:
+      config: ../../.flake8

--- a/roles/virtserver/molecule/default/tests/test_default.py
+++ b/roles/virtserver/molecule/default/tests/test_default.py
@@ -1,4 +1,5 @@
 import os
+import requests
 from testinfra.utils import ansible_runner
 
 testinfra_hosts = ansible_runner.AnsibleRunner(
@@ -15,3 +16,14 @@ def test_libvirt_running_and_enabled(host):
     libvirtd = host.service("libvirtd")
     assert libvirtd.is_enabled
     assert libvirtd.is_running
+
+
+def test_apt_cacher_ng_running_and_enabled(host):
+    apt_cacher_ng = host.service("apt-cacher-ng")
+    assert apt_cacher_ng.is_enabled
+    assert apt_cacher_ng.is_running
+
+
+def test_apt_cacher_ng_response(host):
+    response = requests.get("http://localhost:3142")
+    assert 'virtual HTTP repository' in response.content

--- a/roles/virtserver/molecule/default/tests/test_default.py
+++ b/roles/virtserver/molecule/default/tests/test_default.py
@@ -1,5 +1,4 @@
 import os
-import requests
 from testinfra.utils import ansible_runner
 
 testinfra_hosts = ansible_runner.AnsibleRunner(
@@ -22,8 +21,3 @@ def test_apt_cacher_ng_running_and_enabled(host):
     apt_cacher_ng = host.service("apt-cacher-ng")
     assert apt_cacher_ng.is_enabled
     assert apt_cacher_ng.is_running
-
-
-def test_apt_cacher_ng_response(host):
-    response = requests.get("http://localhost:3142")
-    assert 'virtual HTTP repository' in response.content

--- a/roles/virtserver/molecule/default/tests/test_default.py
+++ b/roles/virtserver/molecule/default/tests/test_default.py
@@ -21,3 +21,8 @@ def test_apt_cacher_ng_running_and_enabled(host):
     apt_cacher_ng = host.service("apt-cacher-ng")
     assert apt_cacher_ng.is_enabled
     assert apt_cacher_ng.is_running
+
+
+def test_apt_cacher_ng_caching_provisioning(host):
+    """Test whether VM guest used apt-cacher-ng on VM host during provisioning"""
+    assert host.file("/var/log/apt-cacher-ng/apt-cacher.log").contains("base-installer")

--- a/roles/virtserver/requirements.yaml
+++ b/roles/virtserver/requirements.yaml
@@ -4,6 +4,10 @@
   src: https://github.com/debops/ansible-libvirtd
   version: v0.3.3
 
+- name: debops.apt_cacher_ng
+  src: https://github.com/debops/ansible-apt_cacher_ng
+  version: v0.2.2
+
 - name: ansible-provisioning
   src: https://github.com/ivan-c/ansible-provisioning
   version: 038e4a179f278ab60d918c47b7e7efb72bcb1da2

--- a/roles/virtserver/tasks/main.yaml
+++ b/roles/virtserver/tasks/main.yaml
@@ -26,7 +26,8 @@
       command: virsh net-define /etc/libvirt/qemu/networks/default.xml
       when: '"default" not in all_libvirt_networks.stdout_lines'
       run_once: true
-
+      notify:
+        - Update network facts
     - name: List enabled libvirt networks
       command: virsh net-list --name
       register: libvirt_networks
@@ -35,6 +36,12 @@
     - name: Start the default network
       command: virsh net-start default
       when: '"default" not in libvirt_networks.stdout_lines'
+      notify:
+        - Update network facts
+
+- name: Flush network handlers
+  meta: flush_handlers
+  delegate_to: "{{ vm_host }}"
 
 - name: Create VM files and directories
   delegate_to: "{{ vm_host }}"

--- a/roles/virtserver/tasks/netboot_debian.yaml
+++ b/roles/virtserver/tasks/netboot_debian.yaml
@@ -54,6 +54,7 @@
     cmdline:
       # 115200 baud, no parity, with 8 data bits
       console=ttyS0,115200n8
+      mirror/http/proxy=http://{{ ansible_virbr0["ipv4"]["address"] }}:3142
       auto-install/enable=true
       preseed/file=/preseed/preseed.cfg
       netcfg/get_hostname={{ inventory_hostname }}

--- a/roles/virtserver/templates/preseed.cfg.j2
+++ b/roles/virtserver/templates/preseed.cfg.j2
@@ -20,7 +20,6 @@ d-i netcfg/choose_interface select auto
 d-i mirror/country string manual
 d-i mirror/http/hostname string http.us.debian.org
 d-i mirror/http/directory string /debian
-d-i mirror/http/proxy string
 
 # Suite to install.
 #d-i mirror/suite string testing


### PR DESCRIPTION
* Install `apt-cacher-ng` on VM hosts
* Configure VM guests to use cache on VM host as proxy
* Allow `http_proxy` specified during testing to be reused for VM host and guest