### PR TITLE
KVM testing passthrough

### DIFF
--- a/roles/virtserver/molecule/default/molecule.yml
+++ b/roles/virtserver/molecule/default/molecule.yml
@@ -31,7 +31,7 @@ provisioner:
         vm_host: "{{ inventory_hostname }}"
         # Pass given proxy to apt-cacher-ng running on VM host
         apt_cacher_ng__proxy: "{{ lookup('env', 'http_proxy') }}"
-        vm_type: qemu
+        vm_type: kvm
         vm_memory: 2048
         vm_vcpu: 2
         vm_creation_timeout: 120

--- a/roles/virtserver/molecule/default/playbook.yml
+++ b/roles/virtserver/molecule/default/playbook.yml
@@ -3,3 +3,19 @@
   hosts: vm_hosts
   roles:
     - role: virtserver
+
+  pre_tasks:
+    - name: Create kvm group
+      delegate_to: "{{ vm_host }}"
+      when: vm_type == 'kvm'
+      block:
+        - name: Get kvm device info
+          stat: path=/dev/kvm
+          register: kvm_dev_info
+
+        - name: Add/update kvm group by gid
+          group:
+            name: kvm
+            gid: "{{ kvm_dev_info.stat.gid }}"
+            state: present
+          when: "'gr_name' not in kvm_dev_info.stat"

--- a/roles/virtserver/molecule/default/tests/test_default.py
+++ b/roles/virtserver/molecule/default/tests/test_default.py
@@ -1,4 +1,5 @@
 import os
+import stat
 from testinfra.utils import ansible_runner
 
 testinfra_hosts = ansible_runner.AnsibleRunner(
@@ -26,3 +27,13 @@ def test_apt_cacher_ng_running_and_enabled(host):
 def test_apt_cacher_ng_caching_provisioning(host):
     """Test whether VM guest used apt-cacher-ng on VM host during provisioning"""
     assert host.file("/var/log/apt-cacher-ng/apt-cacher.log").contains("base-installer")
+
+
+def test_kvm_device(host):
+    kvm_device_path = "/dev/kvm"
+    assert stat.S_ISCHR(os.stat(kvm_device_path).st_mode)
+
+    kvm_device = host.file(kvm_device_path)
+    assert kvm_device.user == "root"
+    assert kvm_device.group == "kvm"
+    assert kvm_device.mode == 0o660

--- a/roles/virtserver/tasks/main.yaml
+++ b/roles/virtserver/tasks/main.yaml
@@ -3,13 +3,6 @@
   meta: flush_handlers
   delegate_to: "{{ vm_host }}"
 
-- name: Add administrators to kvm access group
-  user:
-    name: '{{ item }}'
-    groups: kvm
-    append: yes
-  with_items: '{{ libvirtd__admins }}'
-  when: libvirtd__admins|d() and vm_type == 'kvm'
 
 - name: Create bridge definition
   template:

--- a/roles/virtserver/tasks/main.yaml
+++ b/roles/virtserver/tasks/main.yaml
@@ -3,6 +3,14 @@
   meta: flush_handlers
   delegate_to: "{{ vm_host }}"
 
+- name: Add administrators to kvm access group
+  user:
+    name: '{{ item }}'
+    groups: kvm
+    append: yes
+  with_items: '{{ libvirtd__admins }}'
+  when: libvirtd__admins|d() and vm_type == 'kvm'
+
 - name: Create bridge definition
   template:
     src: libvirt-bridge.j2


### PR DESCRIPTION
* Allow molecule test instance access to `/dev/kvm`
* Provision VMs with KVM by default during testing
